### PR TITLE
fix: install jacked on windows using scoop support 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,4 +51,12 @@
             <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
+    
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/src/main/java/io/jenkins/plugins/jacked/install/AutoInstall.java
+++ b/src/main/java/io/jenkins/plugins/jacked/install/AutoInstall.java
@@ -1,0 +1,19 @@
+package io.jenkins.plugins.jacked.install;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.TaskListener;
+
+public class AutoInstall {
+    public static void Start(Boolean autoInstall, FilePath workspace, EnvVars env, Launcher launcher,
+            TaskListener listener, String osName) throws IOException, InterruptedException, URISyntaxException {
+
+        if (Boolean.TRUE.equals(autoInstall)) {
+            InstallBinary.installJacked(workspace, launcher, listener, env, osName);
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/jacked/install/InstallBinary.java
+++ b/src/main/java/io/jenkins/plugins/jacked/install/InstallBinary.java
@@ -1,12 +1,8 @@
 package io.jenkins.plugins.jacked.install;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 
 import hudson.EnvVars;
 import hudson.FilePath;
@@ -15,42 +11,41 @@ import hudson.model.TaskListener;
 
 public class InstallBinary {
 
-    public static void installJacked(FilePath workspace, Launcher launcher,
-            TaskListener listener, EnvVars env) throws InterruptedException, IOException, URISyntaxException {
-        // Install Jacked
-        String installScriptUrl = "https://raw.githubusercontent.com/carbonetes/jacked/main/install.sh";
-        URI installScriptUri = new URI(installScriptUrl);
-        URL url = installScriptUri.toURL();
-        BufferedReader in = new BufferedReader(new InputStreamReader(url.openStream(), StandardCharsets.UTF_8));
-        StringBuilder script = new StringBuilder();
-        String inputLine;
-        while ((inputLine = in.readLine()) != null) {
-            script.append(inputLine).append("\n");
-        }
-        in.close();
-
-        // Create tmp Directory
+    public static void installJacked(FilePath workspace, Launcher launcher, TaskListener listener, EnvVars env,
+            String osName)
+            throws InterruptedException, IOException, URISyntaxException {
+        // Create a temporary directory inside the workspace to store the downloaded
+        // files
         FilePath jackedTmpDir = workspace.child("jackedTmpDir");
         jackedTmpDir.mkdirs();
 
-        // Store Jacked on tmp Directory
-        FilePath scriptFile = jackedTmpDir.child("install.sh");
-        scriptFile.write(script.toString(), "UTF-8");
+        // Download the install script
+        String installScriptUrl = "https://raw.githubusercontent.com/carbonetes/jacked/main/install.sh";
+        FilePath installScript = jackedTmpDir.child("install.sh");
+        installScript.copyFrom(new URL(installScriptUrl));
 
-        // Launch Install.sh
-        int ret = launcher.launch()
-                .cmds("sh", scriptFile.getRemote())
-                .envs(env)
-                .stdout(listener)
-                .stderr(listener.getLogger())
-                .pwd(workspace)
-                .join();
+        // Set the destination directory where Jacked will be installed
+        FilePath destDir = jackedTmpDir.child("jacked");
 
-        // Check if the installation was successful
+        // Launch the install script with custom options using sh
+        String[] shCmd = { "bash", "install.sh", "-d", destDir.getRemote() };
+        Launcher.ProcStarter procStarter = launcher.launch()
+                .cmds(shCmd)
+                .envs(env).pwd(jackedTmpDir).stdin(null).stdout(listener).stderr(listener.getLogger());
+        int ret = procStarter.start().join();
+
+        // Check if the installation was successful and print a message to the listener
+        // log
         if (ret == 0) {
-            System.out.println("Installation succeeded");
+            listener.getLogger().println("Installation succeeded");
+            if (osName.toLowerCase().contains("windows")) {
+                // Add Jacked to the PATH environment variable
+                String executableFolder = destDir.child("bin").getRemote();
+                env.override("PATH", executableFolder + ";${PATH}");
+            }
         } else {
-            System.out.println("Installation failed - error code: " + ret);
+            listener.getLogger().println("Installation failed - error code: " + ret);
         }
     }
+
 }

--- a/src/main/java/io/jenkins/plugins/jacked/install/Scoop.java
+++ b/src/main/java/io/jenkins/plugins/jacked/install/Scoop.java
@@ -1,0 +1,104 @@
+package io.jenkins.plugins.jacked.install;
+
+import java.io.IOException;
+
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.TaskListener;
+import io.jenkins.plugins.jacked.Jacked;
+
+public class Scoop {
+
+    // Check Scoop
+    public static void checkScoop(FilePath workspace, EnvVars env, Launcher launcher,
+            TaskListener listener,
+            String scanName, String scanType, String severityType, Boolean ciMode)
+            throws IOException, InterruptedException {
+
+        String[] checkScoop = { "powershell.exe", "scoop -v" };
+        Launcher.ProcStarter checkScoopProcStarter = launcher.launch()
+                .cmds(checkScoop)
+                .envs(env).pwd(workspace).stdin(null).stdout(listener).stderr(listener.getLogger());
+        int checkScoopRet = checkScoopProcStarter.start().join();
+
+        if (checkScoopRet != 0) {
+            listener.getLogger().println("Scoop is not installed.");
+            listener.getLogger().println("Preparing to install scoop...");
+            installScoop(workspace, env, launcher, listener, scanName, scanType, severityType,
+                    ciMode);
+        } else {
+            listener.getLogger().println("Preparing to install jacked via scoop...");
+            installJacked(workspace, env, launcher, listener, scanName, scanType, severityType,
+                    ciMode);
+        }
+    }
+
+    // Scoop Install
+    public static void installScoop(FilePath workspace, EnvVars env, Launcher launcher, TaskListener listener,
+            String scanName, String scanType, String severityType, Boolean ciMode)
+            throws IOException, InterruptedException {
+
+        listener.getLogger().println("Installing Scoop...");
+        Process process = new ProcessBuilder("powershell.exe",
+                "Set-ExecutionPolicy RemoteSigned -scope CurrentUser; iwr -useb get.scoop.sh | iex")
+                .redirectErrorStream(true)
+                .start();
+        process.waitFor();
+        listener.getLogger().println("Scoop installation finished");
+        installJacked(workspace, env, launcher, listener, scanName, scanType, severityType,
+                ciMode);
+
+    }
+
+    // Scoop Install Jacked
+    public static void installJacked(FilePath workspace, EnvVars env, Launcher launcher, TaskListener listener,
+            String scanName, String scanType, String severityType, Boolean ciMode)
+            throws IOException, InterruptedException {
+
+        // Clean up jacked bucket
+        String[] bucket = { "powershell", "scoop bucket rm jacked" };
+        cleanUpJacked(bucket, workspace, env, launcher, listener);
+        String[] app = { "powershell", "scoop uninstall jacked" };
+        cleanUpJacked(app, workspace, env, launcher, listener);
+
+        listener.getLogger().println("Preparing to install jacked via scoop...");
+
+        // Add Jacked bucket to Scoop
+        String[] addBucket = { "powershell", "scoop bucket add jacked https://github.com/carbonetes/jacked-bucket" };
+        procCommand(addBucket, workspace, env, launcher, listener);
+        // Install/Update Jacked using Scoop
+        String[] installJacked = { "powershell", "scoop install jacked" };
+        procCommand(installJacked, workspace, env, launcher, listener);
+
+        listener.getLogger().println("Jacked Installed Successfully");
+
+        // Start compiling arguments for scanning
+        Jacked.compileArgs(workspace, env, launcher, listener, scanName, scanType, severityType, ciMode);
+
+    }
+
+    public static void procCommand(String[] args, FilePath workspace, EnvVars env, Launcher launcher,
+            TaskListener listener) throws IOException, InterruptedException {
+
+        Launcher.ProcStarter proc = launcher.launch()
+                .cmds(args)
+                .envs(env).pwd(workspace).stdin(null).stdout(listener).stderr(listener.getLogger());
+        int procCode = proc.join();
+        if (procCode != 0) {
+            listener.getLogger()
+                    .println("Failed to execute command - error code: " + procCode);
+            return;
+        }
+    }
+
+    public static void cleanUpJacked(String[] args, FilePath workspace, EnvVars env, Launcher launcher,
+            TaskListener listener) throws IOException, InterruptedException {
+        Launcher.ProcStarter cleanBucket = launcher.launch()
+                .cmds(args)
+                .envs(env).pwd(workspace).stdin(null).stdout(listener).stderr(listener.getLogger());
+        cleanBucket.join();
+
+    }
+
+}

--- a/src/main/java/io/jenkins/plugins/jacked/os/CheckOS.java
+++ b/src/main/java/io/jenkins/plugins/jacked/os/CheckOS.java
@@ -1,0 +1,15 @@
+package io.jenkins.plugins.jacked.os;
+
+import hudson.model.TaskListener;
+
+public class CheckOS {
+    public static String osName(TaskListener listener) {
+        String osName = System.getProperty("os.name");
+        listener.getLogger().println("Jacked Plugin - Running on: " + osName);
+        return osName;
+    }
+
+    public static Boolean isWindows(String osName) {
+        return osName.toLowerCase().contains("windows");
+    }
+}

--- a/src/main/java/io/jenkins/plugins/jacked/os/Unix.java
+++ b/src/main/java/io/jenkins/plugins/jacked/os/Unix.java
@@ -1,0 +1,12 @@
+package io.jenkins.plugins.jacked.os;
+
+import java.io.IOException;
+
+public class Unix {
+    public static boolean isJackedAvailableUnix() throws IOException, InterruptedException {
+        String[] command = { "which", "jacked" };
+        Process process = new ProcessBuilder(command).start();
+        int exitCode = process.waitFor();
+        return (exitCode == 0);
+    }
+}

--- a/src/main/java/io/jenkins/plugins/jacked/os/Windows.java
+++ b/src/main/java/io/jenkins/plugins/jacked/os/Windows.java
@@ -1,0 +1,13 @@
+package io.jenkins.plugins.jacked.os;
+
+import java.io.IOException;
+
+public class Windows {
+
+    public static boolean isJackedAvailableWindows() throws IOException, InterruptedException {
+        String[] command = { "cmd", "/c", "where", "jacked" };
+        Process process = new ProcessBuilder(command).start();
+        int exitCode = process.waitFor();
+        return (exitCode == 0);
+    }
+}

--- a/src/main/java/io/jenkins/plugins/jacked/scanType/ScanType.java
+++ b/src/main/java/io/jenkins/plugins/jacked/scanType/ScanType.java
@@ -59,7 +59,7 @@ public class ScanType {
                 cmdArgs.add(severityType);
                 break;
         }
-        if (ciMode) {
+        if (Boolean.TRUE.equals(ciMode)) {
             cmdArgs.add(CIMODE);
         }
 

--- a/src/main/resources/io/jenkins/plugins/jacked/Jacked/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/jacked/Jacked/config.jelly
@@ -15,12 +15,12 @@
     </f:entry>
 
     <f:entry field="ciMode">
-      <f:checkbox default="true"/>
+      <f:checkbox />
       <label>${%Enable CI Mode}</label>
     </f:entry> 
 
     <f:entry field="autoInstall">
-      <f:checkbox default="false"/>
+      <f:checkbox />
       <label>${%Download and install jacked automatically}</label>
     </f:entry> 
   </f:section>


### PR DESCRIPTION
Install Support added on Windows Base Image, OS, Agent Node
- Auto-install scoop on Windows, install cleanup, add bucket jacked, scoop install jacked.
- Use scoop installation instead of shell script
